### PR TITLE
Add error if authentication fails.

### DIFF
--- a/dist/classes/api-calls/authenticate.php
+++ b/dist/classes/api-calls/authenticate.php
@@ -19,8 +19,16 @@ class authenticate{
 			'password' => $password
 		);
 
-		return $c->post($url, $data);
+		$user =  $c->post($url, $data);
 
+		// If error logging in, return error and stop running
+		if (isset($user->error)){
+			$r = new response();
+			$r->returnText("Authentication Error: " . $user->error);
+			die();
+		}
+
+		return $user;
 	}
 
 


### PR DESCRIPTION
Rather than continuing to run the script and have a hard fail, return the message to Alexa to respond to the user.

Errors include - Invalid login and Max number of attempts exceeded (which would have been helpful before!)