### PR TITLE
Add error message if the intent can not be found.

### DIFF
--- a/dist/endpoint.php
+++ b/dist/endpoint.php
@@ -22,7 +22,13 @@
 	$EchoReqObj = json_decode($rawJSON);
 
 	// if intent is not set. i.e. you go to the page via http
-	$intent = ( is_object($EchoReqObj) === false ) ? "checkInFiles" : $EchoReqObj->request->intent->name;
+	$intent = ( is_object($EchoReqObj) === false ) ? "unknown" : $EchoReqObj->request->intent->name;
+
+	// abort if the code for the intent can not be found
+	if (!file_exists("classes/tasks/" . $intent . ".php")){
+		$r->returnText("The intent '" . $intent . "' could not be found.");
+		die();
+	}
 
 	// include task class:
 	include_once("classes/tasks/" . $intent . ".php");


### PR DESCRIPTION
This is done with file_exist() as I was not able to get class_exists() to work. This is better than a try/catch as that would make debugging new intents difficult.